### PR TITLE
meilleur explication pour lancer le fichier

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 Script returning number of commit ahead between local repo and remote or between two hashes
 
 How to run :
-- DiffCommit_remote (based on th remote):
-  ./DiffCommit_remote.sh <localpath to repo (required)> <remote/branch (optionnal)>
+- DiffCommit_remote (based on th remote):<br>
+ sh ./DiffCommit_remote.sh <localpath to repo (required)> <remote/branch (optionnal)>
 
 If no remote/branch given, it will perform a detection of the current branch of the local repo. It will automatically connect to "origin/<detected_branch>"
 
-- DiffCommit_commit (based on commit hashes):
-  ./DiffCommit_commit.sh <localpath to repo (required)> <oldcommityouwantotcompare (required)> <recentcommit(required)>
+- DiffCommit_commit (based on commit hashes):<br>
+ sh ./DiffCommit_commit.sh <localpath to repo (required)> <oldcommityouwantotcompare (required)> <recentcommit(required)>


### PR DESCRIPTION
il manquait le "sh" pour les deux cmd et sans connaitre forcément shell c'était pas évidant, aucun message d'erreur direct crash, du coup notice fixée